### PR TITLE
Fix some local development issues

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:3000/api/v1
+VITE_API_URL2=http://localhost:3000

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,16 +43,16 @@ Rails.application.configure do
   config.action_mailer.default_options = { from: "projectawarend@gmail.com" }
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
-    port: 587,
-    domain: "gmail.com",
-    user_name: Rails.application.credentials.gmail[:email],
-    password: Rails.application.credentials.gmail[:password],
-    authentication: "plain",
-    enable_starttls_auto: true
-  }
+  config.action_mailer.delivery_method = :file
+  # config.action_mailer.smtp_settings = {
+  #   address: "smtp.gmail.com",
+  #   port: 587,
+  #   domain: "gmail.com",
+  #   user_name: Rails.application.credentials.gmail[:email],
+  #   password: Rails.application.credentials.gmail[:password],
+  #   authentication: "plain",
+  #   enable_starttls_auto: true
+  # }
 
 
   # Print deprecation notices to the Rails logger.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -295,6 +295,6 @@ impact_kit.kit_items << curious_dog_book << rosie_book << different_book << clas
 # Seeding KitRequests
 
 KitRequest.create([
-  { grade_level: 'PK-2', school_year: '2024-2025', kit: discovery_kit },
-  { grade_level: '3-5', school_year: '2024-2025', kit: empowerment_kit }
+  { school_year: '2024-2025', kit: discovery_kit },
+  { school_year: '2024-2025', kit: empowerment_kit }
 ])


### PR DESCRIPTION
This PR resolves some issues with local development config that would prevent other contributors from starting the local environment.

## Changes

- Add template `.env` file
- Use `:file` for ActionMailer delivery method in `development`
  - Using `Rails.application.credentials` here prevents contributors from being able to edit their own credentials in local development. We can work on a more robust solution to this in the practicum
- Remove `grade_level` from `KitItem`s in the seed file 